### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Sharepoint credentials json
+sharepoint_cred.json


### PR DESCRIPTION
refer to /dashboard/sharepoint_cred_example.json which is added as a placeholder template for the actual cred file